### PR TITLE
fix: Fix elasticapm logger error

### DIFF
--- a/background_task/settings.py
+++ b/background_task/settings.py
@@ -57,5 +57,10 @@ class AppSettings(object):
         else:
             prefix = '-'
         return prefix
+    
+    @property
+    def BACKGROUND_TASKS_MIN_ATTEMPTS_TO_LOG_ERROR(self):
+        """Control how many times a task will be attempted."""
+        return getattr(settings, 'BACKGROUND_TASKS_MIN_ATTEMPTS_TO_LOG_ERROR', 5)
 
 app_settings = AppSettings()

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def update_task_with_error(task, ex):
     t, e, traceback = sys.exc_info()
     if task:
-        if task.attempts > 5:
+        if task.attempts >= 5:
             call_error_log(task)  
         signals.task_error.send(sender=ex.__class__, task=task)
         task.reschedule(t, e, traceback)

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def update_task_with_error(task, ex):
     t, e, traceback = sys.exc_info()
     if task:
-        if task.attempts >= 5:
+        if task.attempts >= app_settings.BACKGROUND_TASKS_MIN_ATTEMPTS_TO_LOG_ERROR:
             call_error_log(task)  
         signals.task_error.send(sender=ex.__class__, task=task)
         task.reschedule(t, e, traceback)

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -23,10 +23,19 @@ logger = logging.getLogger(__name__)
 def update_task_with_error(task, ex):
     t, e, traceback = sys.exc_info()
     if task:
-        logger.error('Rescheduling %s', task, exc_info=(t, e, traceback))
+        if task.attempts <= 5:
+            call_error_log(task, t, e, traceback )  
         signals.task_error.send(sender=ex.__class__, task=task)
         task.reschedule(t, e, traceback)
     del traceback
+
+
+def call_error_log(task ):
+    try:
+        with atomic():
+            logger.error('Rescheduling %s', task, exc_info=True)
+    except:
+        pass
 
 
 @atomic

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -23,14 +23,14 @@ logger = logging.getLogger(__name__)
 def update_task_with_error(task, ex):
     t, e, traceback = sys.exc_info()
     if task:
-        if task.attempts <= 5:
-            call_error_log(task, t, e, traceback )  
+        if task.attempts > 5:
+            call_error_log(task)  
         signals.task_error.send(sender=ex.__class__, task=task)
         task.reschedule(t, e, traceback)
     del traceback
 
 
-def call_error_log(task ):
+def call_error_log(task):
     try:
         with atomic():
             logger.error('Rescheduling %s', task, exc_info=True)


### PR DESCRIPTION
Quando habilitado, o Elastic APM realizava transações para o banco de dados durante o log de erros. Devido às funções que gerenciam as tarefas estarem dentro de blocos atômicos, quando alguma transação do Elastic falhava, era desencadeado o rollback de todas as funções atômicas em que o logger estava, resultando na falha em reagendar uma tarefa com erro e, por consequência, a falha do worker.

Para solucionar o problema, fizemos o tratamento da exceção gerada pela transação interna do Elastic quando realizada dentro de um bloco atômico, evitando que o erro dessa transação afete as demais operações realizadas pelo bg_tasks.